### PR TITLE
Reject undersized UDP packets before reading header fields

### DIFF
--- a/src/biblesync.cc
+++ b/src/biblesync.cc
@@ -377,6 +377,14 @@ int BibleSync::ReceiveInternal()
     // whether it passes muster for BibleSync is another matter.
     while ((recv_size = InitSelectRead(dump, &source, &bsp)) > 0)
     {
+	if (recv_size < BSP_HEADER_SIZE)
+	{
+	    (*nav_func)('E', EMPTY,
+			EMPTY, EMPTY, EMPTY, EMPTY, EMPTY,
+			BSP + _("packet too short"), dump);
+	    continue;
+	}
+
 	((char*)&bsp)[recv_size] = '\0';	// as an ordinary C string
 
 	// dump content into something humanly useful.


### PR DESCRIPTION
ReceiveInternal formats the received packet's uuid and body into a
diagnostic dump that is passed to the application's nav_func callback,
but there was no minimum length check after recvfrom. A packet shorter
than BSP_HEADER_SIZE (32 bytes) leaves the uuid field and body as
uninitialized stack memory, which then gets formatted into the dump.
MemorySanitizer confirms use-of-uninitialized-value on the uuid read
after a 6-byte recvfrom.

This adds a recv_size < BSP_HEADER_SIZE check right after recvfrom
returns. Undersized packets are reported as an error via nav_func and
skipped before any uninitialized header field is read.