### PR TITLE
Sanitize chat newlines before storing in the content map

### DIFF
--- a/src/biblesync.cc
+++ b/src/biblesync.cc
@@ -816,10 +816,10 @@ BibleSync::TransmitInternal(char message_type,
     if (message_type != BSP_CHAT)
 	content[BSP_MSG_SYNC_BIBLEABBREV] = bible;
     else {
-	content[BSP_MSG_CHAT]	          = bible;	// overload.
 	// innoculate chat content against internal \n.
 	for (char *chase = (char *)bible.c_str(); chase = strchr(chase, '\n'); ++chase)
 	    *chase = '\t';
+	content[BSP_MSG_CHAT]	          = bible;	// overload.
     }
     content[BSP_MSG_SYNC_VERSE]           = ref;
     content[BSP_MSG_SYNC_ALTVERSE]        = alt;


### PR DESCRIPTION
TransmitInternal inoculates chat content against internal newlines so
they cannot break the name=value body format. The inoculation loop
replaces \n with \t, but it ran after the raw message was already
copied into the content map, so the map entry retained the original
newlines. A chat message like "Hello\nmsg.sync.passPhrase=Injected"
becomes two protocol fields at the receiver, and the map's
last-write-wins semantics let the injected field override the
legitimate value.

This moves the \n-to-\t substitution before the assignment to
content[BSP_MSG_CHAT] so the sanitized value is what gets stored and
transmitted.