### PR TITLE
Guard get_default_if_name against empty or unparseable /proc/net/route

### DIFF
--- a/src/biblesync.cc
+++ b/src/biblesync.cc
@@ -977,8 +977,10 @@ void BibleSync::clearSpeakers()
 int BibleSync::get_default_if_name(char *name)
 {
     int found = 0;
-    char line[256], *field;
+    char line[256], *field = NULL;
     FILE *proc_route;
+
+    line[0] = '\0';
 
     if ((proc_route = fopen(PROC_ROUTE, "r")) == NULL)
     {
@@ -1001,12 +1003,14 @@ int BibleSync::get_default_if_name(char *name)
     }
     fclose(proc_route);
 
-    if (!found)
+    if (!found && field != NULL && line[0] != '\0')
     {
-	// no default route?  fallback: we're holding a valid last line.
-	// so we arbitrarily choose whatever was found there.
 	*field = '\0';
 	strcpy(name, line);
+    }
+    else if (!found)
+    {
+	name[0] = '\0';
     }
 
     return 0;


### PR DESCRIPTION
get_default_if_name reads /proc/net/route looking for the default
route. The fallback block that runs when no default route is found
dereferences the uninitialized 'field' pointer and copies the
uninitialized 'line' buffer into the caller's 16-byte destination.

Two failure modes exist:
- An empty /proc/net/route leaves both 'field' and 'line' entirely
  uninitialized; *field writes to an arbitrary stack location and
  strcpy(name, line) overflows the 16-byte destination.
- A file with lines but no tabs leaves 'field' NULL from the last
  strchr call; *field = '\0' is a null pointer dereference.

This initializes field to NULL and line[0] to '\0' before the loop,
guards the fallback block so it only runs when a valid last line was
seen, and sets name[0] = '\0' when the guard fails so the caller
InterfaceAddress() keeps its 127.0.0.1 fallback instead of reading
the uninitialized gw_if buffer.