### PR TITLE
Guard optional body field lookups against missing keys

### DIFF
--- a/src/biblesync.cc
+++ b/src/biblesync.cc
@@ -553,7 +553,10 @@ int BibleSync::ReceiveInternal()
 			info = "<>";
 		    char cmd;
 
-		    string version = content.find(BSP_APP_VERSION)->second;
+		    string version;
+		    auto ver_it = content.find(BSP_APP_VERSION);
+		    if (ver_it != content.end())
+			version = ver_it->second;
 		    if (version == "")
 			version = (string)"(version?)";
 		
@@ -564,7 +567,11 @@ int BibleSync::ReceiveInternal()
 			ref    = source_addr;
 			group  = content.find(BSP_APP_NAME)->second
 			    + " " + version;
-			domain = content.find(BSP_APP_DEVICE)->second;
+			{
+			    auto dev_it = content.find(BSP_APP_DEVICE);
+			    if (dev_it != content.end())
+				domain = dev_it->second;
+			}
 			alt    = content.find(BSP_MSG_CHAT)->second;
 
 			info = (string)"chat: "
@@ -581,7 +588,11 @@ int BibleSync::ReceiveInternal()
 			// regular synchronized navigation
 			bible  = content.find(BSP_MSG_SYNC_BIBLEABBREV)->second;
 			ref    = content.find(BSP_MSG_SYNC_VERSE)->second;
-			alt    = content.find(BSP_MSG_SYNC_ALTVERSE)->second;
+			{
+			    auto alt_it = content.find(BSP_MSG_SYNC_ALTVERSE);
+			    if (alt_it != content.end())
+				alt = alt_it->second;
+			}
 			group  = content.find(BSP_MSG_SYNC_GROUP)->second;
 			domain = content.find(BSP_MSG_SYNC_DOMAIN)->second;
 
@@ -623,7 +634,11 @@ int BibleSync::ReceiveInternal()
 			ref    = source_addr;
 			group  = content.find(BSP_APP_NAME)->second
 			    + " " + version;
-			domain = content.find(BSP_APP_DEVICE)->second;
+			{
+			    auto dev_it = content.find(BSP_APP_DEVICE);
+			    if (dev_it != content.end())
+				domain = dev_it->second;
+			}
 
 			alt = BSP
 			    + content.find(BSP_APP_USER)->second
@@ -648,7 +663,11 @@ int BibleSync::ReceiveInternal()
 			ref    = source_addr;
 			group  = content.find(BSP_APP_NAME)->second
 			    + " " + version;
-			domain = content.find(BSP_APP_DEVICE)->second;
+			{
+			    auto dev_it = content.find(BSP_APP_DEVICE);
+			    if (dev_it != content.end())
+				domain = dev_it->second;
+			}
 
 			info = (string)"beacon: "
 			    + content.find(BSP_APP_USER)->second


### PR DESCRIPTION
ReceiveInternal validates required body fields before processing, but
three optional fields are accessed via content.find(key)->second
without checking whether the key exists:

  - BSP_APP_VERSION       (app.version)        all message types
  - BSP_APP_DEVICE        (app.device)         CHAT, ANNOUNCE, BEACON
  - BSP_MSG_SYNC_ALTVERSE (msg.sync.altVerse)  SYNC

A packet that passes the required-field check but omits these
optional fields causes content.find() to return the past-the-end
iterator, and dereferencing ->second is undefined behavior. On
libstdc++ this manifests as std::bad_alloc; other STL implementations
may crash or silently propagate garbage to the nav_func callback.

This guards each lookup with an existence check. The affected local
variables are already initialized to safe defaults, so a missing
field leaves the default in place.